### PR TITLE
dsstox_structure id missing in CompTox sources

### DIFF
--- a/inst/scripts/make-data.R
+++ b/inst/scripts/make-data.R
@@ -399,6 +399,8 @@ if( !file.exists( comptoxfile) || recompute){
     comptox_pubchem <- read.csv( file = destfile, header = TRUE, sep = "\t")
     comptox_pubchem <- as_tibble( comptox_pubchem) %>% mutate_all( as.character)
 
+    # TODO
+    # the file reference here dows not contain DTXCID (dsstox_structure_id)
     cat( "Download Comptox CAS IDs ...\n")
     linenr <- grep( "DSSTox identifiers mapped to CAS Numbers and Names File",
                     readLines( masterfile))


### PR DESCRIPTION
Hi Sebastian,
when trying to combine the dataset on my one I run into an error, because one of the imported datasets does not contain a column (dsstox_structure_id) that you are referencing. 
I have not found a solution yet, maybe you want to look into that yourself. I've marked the relevant lines of code.
Best,
Max